### PR TITLE
Add WinGet Releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,13 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v1
+        with:
+          identifier: Harmonoid.Harmonoid
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This pull request adds a workflow that automatically publishes Harmonoid to WinGet every release. *Please do not merge this pull request without reading the below and making the required changes*.

- `token: ${{ secrets.WINGET_TOKEN }}`

This is the bit that will require action from you. This is a GitHub token with which the action will authenticate with GitHub and create a pull request on the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.

To do this, you will need to:

1. Create a Personal Access Token (PAT) with `public_repo` scope.

![image](https://user-images.githubusercontent.com/74878137/170548538-0d689177-5c9e-4bb2-8a87-e09eb5ca64e8.png)

2. Create a repository secret containing the token. **Super important: call this token: `WINGET_TOKEN`**.
See [using encrypted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) for more details.

</br>

**Finally, a fork of [winget-pkgs](https://github.com/microsoft/winget-pkgs) needs to be created under the your account. Please do not delete the fork after a pull request has been merged as the action will use that fork for making a branch and merging it with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every Harmonoid release.**

If you would like to read about this action further, the source code and documentation are [here](https://github.com/vedantmgoyal2009/winget-releaser).